### PR TITLE
:sparkles: [LMS] Show unit in course outline

### DIFF
--- a/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
@@ -79,101 +79,60 @@ dates_banner_displayed = False
                     </script>
                 % endif
                         <li class="subsection accordion ${ 'current' if subsection.get('resume_block') else '' } ${graded} ${scored}">
-                            <a
-                            % if enable_links:
-                                href="${ subsection['lms_web_url'] }"
-                            % else:
-                                aria-disabled="true"
-                            % endif
-                                class="subsection-text outline-button"
-                                id="${ subsection['id'] }"
-                            >
-                            % if graded and scored and 'special_exam_info' not in subsection:
-                                      <span class="icon fa fa-pencil-square-o" aria-hidden="true"></span>
-                            % endif
-                                      <h4 class="subsection-title">
-                                          ${ subsection['display_name'] }
-                            % if num_graded_problems:
-                                          ${ngettext("({number} Question)",
-                                                     "({number} Questions)",
-                                                     num_graded_problems).format(number=num_graded_problems)}
-                            % endif
-                                      </h4>
-                            % if subsection.get('complete'):
-                                <span class="complete-checkmark fa fa-check" aria-hidden="true"></span>
-                                <span class="sr">${_("Completed")}</span>
-                            % endif
-                            % if needs_prereqs:
-                                    <div class="details prerequisite">
-                                        <span class="prerequisites-icon icon fa fa-lock" aria-hidden="true"></span>
-                                        ${ _("Prerequisite: ") }
-                                            <%
-                                                prerequisite_id = gated_content[subsection['id']]['prerequisite']
-                                                prerequisite_name = xblock_display_names.get(prerequisite_id)
-                                            %>
-                                            ${ prerequisite_name }
-                                    </div>
-                            % endif
-                                        <div class="details">
-
-                ## There are behavior differences between rendering of subsections which have
-                ## exams (timed, graded, etc) and those that do not.
-                ##
-                ## Exam subsections expose exam status message field as well as a status icon
-                <%
-                if subsection.get('due') is None or (self_paced and not in_edx_when):
-                    # examples: Homework, Lab, etc.
-                    data_string = subsection.get('format')
-                    data_datetime = ""
-                else:
-                    if 'special_exam_info' in subsection:
-                        data_string = _('due {date}')
-                    else:
-                        data_string = _("{subsection_format} due {{date}}").format(subsection_format=subsection.get('format'))
-                    data_datetime = subsection.get('due')
-                %>
-                % if subsection.get('format') or 'special_exam_info' in subsection:
-                                            <span class="subtitle">
-                    % if 'special_exam_info' in subsection:
-                                                    ## Display the exam status icon and status message
-                                                    <span
-                                                        class="menu-icon icon fa ${subsection['special_exam_info'].get('suggested_icon', 'fa-pencil-square-o')} ${subsection['special_exam_info'].get('status', 'eligible')}"
-                                                        aria-hidden="true"
-                                                    ></span>
-                                                    <span class="subtitle-name">
-                                                        ${subsection['special_exam_info'].get('short_description', '')}
-                                                    </span>
-
-                        ## completed exam statuses should not show the due date
-                        ## since the exam has already been submitted by the user
-                        % if not subsection['special_exam_info'].get('in_completed_state', False):
-                                                        <span
-                                                            class="localized-datetime subtitle-name"
-                                                            data-datetime="${data_datetime}"
-                                                            data-string="${data_string}"
-                                                            data-timezone="${user_timezone}"
-                                                            data-language="${user_language}"
-                                                        ></span>
-                        % endif
-                    % else:
-                                                    ## non-graded section, we just show the exam format and the due date
-                                                    ## this is the standard case in edx-platform
-                                                    <span
-                                                        class="localized-datetime subtitle-name"
-                                                        data-datetime="${data_datetime}"
-                                                        data-string="${data_string}"
-                                                        data-timezone="${user_timezone}"
-                                                        data-language="${user_language}"
-                                                    ></span>
-
-                        % if subsection.get('graded'):
-                                                <span class="sr">&nbsp;${_("This content is graded")}</span>
-                        % endif
-                    % endif
-                                            </span>
+                            <button class="section-name accordion-trigger outline-button" 
+                                    aria-expanded="${ 'true' if subsection_is_auto_opened else 'false' }"
+                                    aria-controls="${ subsection['id'] }_contents"
+                                    id="${ subsection['id']}">
+                                    <span class="fa fa-chevron-right ${ 'fa-rotate-90' if section_is_auto_opened else '' }" aria-hidden="true"></span>
+                                    <h3 class="section-title">
+                % if graded and scored and 'special_exam_info' not in subsection:
+                                        <span class="icon fa fa-pencil-square-o" aria-hidden="true"></span>
                 % endif
-                                        </div> <!-- /details -->
-                            </a>
+                                        ${ subsection['display_name'] }
+                % if num_graded_problems:
+                                        ${ngettext("({number} Question)",
+                                                    "({number} Questions)",
+                                                    num_graded_problems).format(number=num_graded_problems)}
+                % endif
+                                    </h3>
+                % if subsection.get('complete'):
+                                    <span class="complete-checkmark fa fa-check" aria-hidden="true"></span>
+                                    <span class="sr">${_("Completed")}</span>
+                % endif
+                            </button>
+                            <ol class="outline-item accordion-panel ${ '' if section_is_auto_opened else 'is-hidden' }"
+                                id="${ subsection['id'] }_contents"
+                                aria-labelledby="${ subsection['id'] }">
+                % for vertical in subsection.get('children', []):
+                    <%
+                    vertical_num_graded_problems = vertical.get('num_graded_problems', 0)
+                    %>
+                                <li class="subsection accordion">
+                                    <a 
+                                    % if enable_links:
+                                        href="${ vertical['lms_web_url'] }"
+                                    % else:
+                                        aria-disabled="true"
+                                    % endif
+                                        class="subsection-text outline-button"
+                                        id="${ vertical['id'] }"
+                                    >
+                                        <h4 class="subsection-title">
+                                            ${ vertical['display_name'] }
+                    % if vertical_num_graded_problems:
+                                            ${ngettext("({number} Question)",
+                                                        "({number} Questions)",
+                                                        vertical_num_graded_problems).format(number=vertical_num_graded_problems)}
+                    % endif
+                                        </h4>
+                    % if vertical.get('complete'):
+                                        <span class="complete-checkmark fa fa-check" aria-hidden="true"></span>
+                                        <span class="sr">${_("Completed")}</span>
+                    % endif
+                                    </a>
+                                </li>
+                % endfor
+                            </ol>
                         </li>
             % endfor
                     </ol>


### PR DESCRIPTION
We transform each subsection into an accordion (similar to sections), then display its associated units as accordion items.
When users click the unit, they are navigated to that specific unit.

**NOTE:** Before this PR, Each subsection also displays a prerequisite / due date if specified. 
In this PR, we haven't implemented how we would display such information yet. 