### PR TITLE
:ambulance: Hotfix incorrect translation for user test

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -259,7 +259,7 @@ def get_component_templates(courselike, library=False):
         'discussion': _("Discussion"),
         'html': _("HTML"),
         'problem': _("Problem"),
-        'video': _("Video")
+        'video': "วิดีโอ" # _("Video")
     }
 
     component_templates = []

--- a/cms/static/js/views/settings/advanced.js
+++ b/cms/static/js/views/settings/advanced.js
@@ -65,7 +65,7 @@ define(['js/views/validation',
                     instance.save();
                 // this event's being called even when there's no change :-(
                     if (instance.getValue() !== oldValue) {
-                        var message = gettext('Your changes will not take effect until you save your progress. Take care with key and value formatting, as validation is not implemented.');
+                        var message = /* gettext('Your changes will not take effect until you save your progress. Take care with key and value formatting, as validation is not implemented.'); */ 'การเปลี่ยนแปลงของคุณจะไม่มีผลจนกว่าคุณจะเลือก "บันทึกการเปลี่ยนแปลง"';
                         self.showNotificationBar(message,
                                              _.bind(self.saveView, self),
                                              _.bind(self.revertView, self));
@@ -114,8 +114,8 @@ define(['js/views/validation',
                 var self = this;
                 this.model.save({}, {
                     success: function() {
-                        var title = gettext('Your policy changes have been saved.');
-                        var message = gettext('No validation is performed on policy keys or value pairs. If you are having difficulties, check your formatting.');  // eslint-disable-line max-len
+                        var title = /* gettext('Your policy changes have been saved.') */ 'การเปลี่ยนแปลงของคุณได้รับการบันทึกแล้ว';
+                        var message = /* gettext('No validation is performed on policy keys or value pairs. If you are having difficulties, check your formatting.'); */ '';  // eslint-disable-line max-len
                         self.render();
                         self.showSavedBar(title, message);
                         analytics.track('Saved Advanced Settings', {

--- a/common/static/common/js/components/utils/view_utils.js
+++ b/common/static/common/js/components/utils/view_utils.js
@@ -212,7 +212,7 @@
              * Helper method for course/library creation - verifies a required field is not blank.
              */
             validateRequiredField = function(msg) {
-                return msg.length === 0 ? gettext('Required field.') : '';
+                return msg.length === 0 ? /* gettext('Required field.') */ 'ห้ามเว้นว่าง' : '';
             };
 
             /**
@@ -230,7 +230,7 @@
                     }
                 } else {
                     if (item !== encodeURIComponent(item) || item.match(/[!'()*]/)) {
-                        return gettext('Please do not use any spaces or special characters in this field.');
+                        return /* gettext('Please do not use any spaces or special characters in this field.') */ 'ห้ามใช้ภาษาไทย ค่าว่าง หรืออักขระพิเศษ';
                     }
                 }
                 return '';


### PR DESCRIPTION
There are some texts that their translation did not get updated, although we have changed the translation text in `*.po` files.

As a hotfix, we change these texts directly in the code. This would make these texts unable to change according to the current language. 
It should be fine, though, since we do not allow users to change to other languages aside from Thai anyway.